### PR TITLE
Remove the org.apache.http.legacy call

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -39,8 +39,7 @@ PRODUCT_PACKAGES += \
     mount.exfat \
     mkfs.exfat \
     mkntfs \
-    busybox \
-    org.apache.http.legacy
+    busybox
 
 PRODUCT_PACKAGES += libkatcam \
  		libkatomx


### PR DESCRIPTION
Unfortunately we cannot add it this way, see logcat error:

07-17 20:11:10.273 W/PackageManager( 1524): Library not found: /system/framework/org.apache.http.legacy.jar

The only solution is to add the jar file to the proprietary prebuilts
